### PR TITLE
Update .npmignore to exclude more unnecessary files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,6 +20,8 @@
 /.git/
 /.github/
 /.gitignore
+/.prettierignore
+/.prettierrc.js
 /.release-plan.json
 /.template-lintrc.js
 /.travis.yml
@@ -32,6 +34,7 @@
 /testem.js
 /tests/
 /tests-babel/
+/tsconfig.json
 /yarn.lock
 .gitkeep
 


### PR DESCRIPTION
In #258 addressed new files that got into npm bundle in v4.1.2 but couple other files also not needed and were present before v4.1.2