### PR TITLE
Update readme compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ include `@glint/environment-ember-template-imports`!)
 
 ## Compatibility
 
-* Ember.js v3.27 or above
-* Ember CLI v3.27 or above
+* Ember.js v4.12 or above
+* Ember CLI v4.12 or above
 * `ember-cli-htmlbars` 6.3.0 or above
-* Node.js v12 or above
+* Node.js v16 or above
 
 
 ## Editor Integrations

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ include `@glint/environment-ember-template-imports`!)
 
 ## Compatibility
 
-* Ember.js v4.12 or above
+* Ember.js v3.27 or above
 * Ember CLI v3.27 or above
 * `ember-cli-htmlbars` 6.3.0 or above
 * Node.js v16 or above

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ include `@glint/environment-ember-template-imports`!)
 ## Compatibility
 
 * Ember.js v4.12 or above
-* Ember CLI v4.12 or above
+* Ember CLI v3.27 or above
 * `ember-cli-htmlbars` 6.3.0 or above
 * Node.js v16 or above
 


### PR DESCRIPTION
Node.js minimum up to v16
Ember minimum up to v4.12


I focused on package.json, if Ember enhancement is not required, I will fix it
