### PR TITLE
Enable `inline_source_map` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,14 +283,14 @@ module('Integration | Component | hello', function (hooks) {
 
 ## Sourcemap Generation
 
-This can be useful for development and test purposes, it should be disabled for production
+Inline sourcemaps are inserted automatically, which downstream build tooling may extract or remove. To disable this sourcemap injection, set the `inline_source_map` flag to `false`:
 
 ```js
 // ember-cli-build.js
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
     'ember-template-imports': {
-      inline_source_map: true
+      inline_source_map: false
     }
   });
 ```

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -89,6 +89,11 @@ module.exports = {
 
     const options = parentOptions || appOptions || {};
 
-    return options['ember-template-imports'] || { inline_source_map: false };
+    const defaults = { inline_source_map: true };
+
+    return {
+      ...defaults,
+      ...options['ember-template-imports'],
+    };
   },
 };


### PR DESCRIPTION
Inline sourcemaps are extracted or deleted by downstream build tooling, depending on their own sourcemap config (verified in both classic & embroider builds). Therefore, there is no downside to enabling inline_source_map by default in this addon, so that people get a better development experience by default.